### PR TITLE
Fix calculation formulas

### DIFF
--- a/src/components/ScenarioAnalysis.tsx
+++ b/src/components/ScenarioAnalysis.tsx
@@ -26,26 +26,27 @@ interface Scenario {
 
 const ScenarioAnalysis: React.FC<ScenarioAnalysisProps> = ({ formData, results }) => {
   const { language } = useLanguage();
+  const baseYield = 100 - formData.cleaningLoss - formData.processingLoss;
   const [scenarios, setScenarios] = useState<Scenario[]>([
     {
       id: '1',
       name: language === 'el' ? 'Βασικό Σενάριο' : 'Base Scenario',
       costPerKg: formData.costPerKg,
-      cleaningYield: formData.cleaningYield,
+      cleaningYield: baseYield,
       profitMargin: formData.profitMargin
     },
     {
       id: '2',
       name: language === 'el' ? 'Αισιόδοξο Σενάριο' : 'Optimistic Scenario',
       costPerKg: formData.costPerKg * 0.9,
-      cleaningYield: Math.min(formData.cleaningYield + 5, 95),
+      cleaningYield: Math.min(baseYield + 5, 95),
       profitMargin: formData.profitMargin + 5
     },
     {
       id: '3',
       name: language === 'el' ? 'Απαισιόδοξο Σενάριο' : 'Pessimistic Scenario',
       costPerKg: formData.costPerKg * 1.1,
-      cleaningYield: Math.max(formData.cleaningYield - 5, 70),
+      cleaningYield: Math.max(baseYield - 5, 70),
       profitMargin: Math.max(formData.profitMargin - 5, 10)
     }
   ]);
@@ -53,17 +54,22 @@ const ScenarioAnalysis: React.FC<ScenarioAnalysisProps> = ({ formData, results }
   const [newScenario, setNewScenario] = useState({
     name: '',
     costPerKg: formData.costPerKg,
-    cleaningYield: formData.cleaningYield,
+    cleaningYield: baseYield,
     profitMargin: formData.profitMargin
   });
 
   const calculateScenario = (scenario: Scenario): CalculationResults => {
     const cleanWeight = formData.initialWeight * (scenario.cleaningYield / 100);
-    const finalWeight = cleanWeight * (1 + formData.glazingPercentage / 100);
+    const finalWeight = cleanWeight * (1 + formData.glazingWeight / 100);
     
     const materialCost = formData.initialWeight * scenario.costPerKg;
-    const totalDirectCosts = materialCost + formData.transportCost + formData.laborCost + formData.packagingCost + formData.additionalCosts;
-    const totalCost = totalDirectCosts * (1 + formData.markupPercentage / 100);
+    const totalDirectCosts =
+      materialCost +
+      formData.transportCost +
+      formData.laborCost +
+      formData.packagingCost +
+      formData.additionalCosts;
+    const totalCost = totalDirectCosts;
     const costPerKgFinal = totalCost / finalWeight;
     const sellingPrice = totalCost * (1 + scenario.profitMargin / 100);
     const profit = sellingPrice - totalCost;
@@ -93,7 +99,7 @@ const ScenarioAnalysis: React.FC<ScenarioAnalysisProps> = ({ formData, results }
     setNewScenario({
       name: '',
       costPerKg: formData.costPerKg,
-      cleaningYield: formData.cleaningYield,
+      cleaningYield: baseYield,
       profitMargin: formData.profitMargin
     });
   };

--- a/src/hooks/useCalculation.ts
+++ b/src/hooks/useCalculation.ts
@@ -9,9 +9,6 @@ const initialFormData: FormData = {
   glazingWeight: 0,
   costPerKg: 0,
   profitMargin: 20,
-  cleaningYield: 85,
-  glazingPercentage: 15,
-  markupPercentage: 20,
   transportCost: 0,
   laborCost: 0,
   packagingCost: 0,
@@ -34,16 +31,18 @@ export const useCalculation = () => {
       // Simulate async calculation
       await new Promise(resolve => setTimeout(resolve, 500));
       
-      const cleanWeight = formData.initialWeight * (formData.cleaningYield / 100);
-      const finalWeight = cleanWeight * (1 + formData.glazingPercentage / 100);
+      const cleanWeight =
+        formData.initialWeight *
+        (1 - (formData.cleaningLoss + formData.processingLoss) / 100);
+      const finalWeight = cleanWeight * (1 + formData.glazingWeight / 100);
       
       const materialCost = formData.initialWeight * formData.costPerKg;
       const totalDirectCosts = materialCost + formData.transportCost + formData.laborCost + formData.packagingCost + formData.additionalCosts;
-      const totalCost = totalDirectCosts * (1 + formData.markupPercentage / 100);
+      const totalCost = totalDirectCosts;
       const costPerKgFinal = totalCost / finalWeight;
       const costPerKg = costPerKgFinal;
-      const sellingPrice = totalCost;
-      const profit = totalCost - totalDirectCosts;
+      const sellingPrice = totalCost * (1 + formData.profitMargin / 100);
+      const profit = sellingPrice - totalCost;
       
       const calculationResults: CalculationResults = {
         cleanWeight,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,9 +6,6 @@ export interface FormData {
   glazingWeight: number;
   costPerKg: number;
   profitMargin: number;
-  cleaningYield: number;
-  glazingPercentage: number;
-  markupPercentage: number;
   transportCost: number;
   laborCost: number;
   packagingCost: number;


### PR DESCRIPTION
## Summary
- fix profit and yield formulas in useCalculation
- use new formulas in ScenarioAnalysis
- simplify FormData fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee4f552c83289add9c29333049fe