### PR TITLE
Fix translation keys, toast hook and dynamic styles

### DIFF
--- a/src/components/StatisticalModels.tsx
+++ b/src/components/StatisticalModels.tsx
@@ -195,16 +195,15 @@ const StatisticalModels: React.FC<StatisticalModelsProps> = ({ formData, results
         );
 
       case 'risk':
-        const riskColors = {
-          low: 'green',
-          medium: 'yellow',
-          high: 'red'
+        const riskBgClass: Record<string, string> = {
+          low: 'bg-green-50',
+          medium: 'bg-yellow-50',
+          high: 'bg-red-50'
         };
-        const riskColor = riskColors[model.data.riskLevel as keyof typeof riskColors];
-        
+
         return (
           <div className="space-y-4">
-            <div className={`p-4 bg-${riskColor}-50 rounded-lg`}>
+            <div className={`p-4 ${riskBgClass[model.data.riskLevel]} rounded-lg`}>
               <div className="flex items-center space-x-2 mb-2">
                 <Badge variant={model.data.riskLevel === 'low' ? 'default' : 'destructive'}>
                   {language === 'el' 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -41,6 +41,8 @@ const translations = {
     'workers': 'Εργαζόμενοι',
     'hourly.rate': 'Ωριαία Αμοιβή (€)',
     'hours': 'Ώρες Εργασίας',
+    'worker.hourly.rate': 'Ωριαία Αμοιβή (€)',
+    'worker.hours': 'Ώρες Εργασίας',
     
     // Costs
     'packaging.cost': 'Κόστος Συσκευασίας (€)',
@@ -93,6 +95,8 @@ const translations = {
     'workers': 'Workers',
     'hourly.rate': 'Hourly Rate (€)',
     'hours': 'Working Hours',
+    'worker.hourly.rate': 'Hourly Rate (€)',
+    'worker.hours': 'Working Hours',
     
     // Costs
     'packaging.cost': 'Packaging Cost (€)',

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- add missing worker translation keys
- prevent useToast from adding duplicate listeners
- replace dynamic Tailwind class in statistical models

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685c2a44beac8328b05cf91519921156