### PR TITLE
Update results layout

### DIFF
--- a/src/components/ResultsSection.tsx
+++ b/src/components/ResultsSection.tsx
@@ -166,44 +166,44 @@ const ResultsSection: React.FC<ResultsSectionProps> = ({
           </CardTitle>
         </CardHeader>
         <CardContent className="p-6">
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-            <div className="bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 rounded-xl p-6 text-center">
-              <div className="text-xs font-semibold text-blue-600 uppercase tracking-wide mb-2">
-                {language === 'el' ? 'Συνολικό Κόστος' : 'Total Cost'}
+          <div className="flex flex-wrap gap-4 mb-6">
+            {[
+              {
+                label: language === 'el' ? 'Συνολικό Κόστος' : 'Total Cost',
+                value: `${results.totalCost.toFixed(2)}€`,
+                color: 'from-blue-50 to-blue-100 border-blue-200 text-blue-600',
+              },
+              {
+                label: language === 'el' ? 'Τιμή Πώλησης' : 'Selling Price',
+                value: `${results.sellingPrice.toFixed(2)}€`,
+                color: 'from-green-50 to-green-100 border-green-200 text-green-600',
+              },
+              {
+                label: language === 'el' ? 'Κέρδος/Κιλό' : 'Profit/Kg',
+                value: `${results.profitPerKg.toFixed(2)}€`,
+                color: 'from-purple-50 to-purple-100 border-purple-200 text-purple-600',
+              },
+              {
+                label: language === 'el' ? 'Περιθώριο %' : 'Margin %',
+                value: `${results.profitMargin.toFixed(1)}%`,
+                color: 'from-orange-50 to-orange-100 border-orange-200 text-orange-600',
+              },
+            ].map(({ label, value, color }, i) => (
+              <div
+                key={i}
+                className={`
+                  flex-1 min-w-[100px] max-w-[200px]
+                  bg-gradient-to-br ${color}
+                  border rounded-xl p-4 text-center
+                  truncate
+                `}
+              >
+                <div className="text-xs font-semibold uppercase tracking-wide mb-1 truncate">
+                  {label}
+                </div>
+                <div className="text-2xl font-bold truncate">{value}</div>
               </div>
-              <div className="text-2xl font-bold text-slate-900 flex items-center justify-center space-x-2">
-                <Calculator className="w-5 h-5" />
-                <span>{results.totalCost.toFixed(2)}€</span>
-              </div>
-            </div>
-
-            <div className="bg-gradient-to-br from-green-50 to-green-100 border border-green-200 rounded-xl p-6 text-center">
-              <div className="text-xs font-semibold text-green-600 uppercase tracking-wide mb-2">
-                {language === 'el' ? 'Τιμή Πώλησης' : 'Selling Price'}
-              </div>
-              <div className="text-2xl font-bold text-slate-900 flex items-center justify-center space-x-2">
-                <TrendingUp className="w-5 h-5" />
-                <span>{results.sellingPrice.toFixed(2)}€</span>
-              </div>
-            </div>
-
-            <div className="bg-gradient-to-br from-purple-50 to-purple-100 border border-purple-200 rounded-xl p-6 text-center">
-              <div className="text-xs font-semibold text-purple-600 uppercase tracking-wide mb-2">
-                {language === 'el' ? 'Κέρδος/Κιλό' : 'Profit/Kg'}
-              </div>
-              <div className="text-2xl font-bold text-slate-900">
-                {results.profitPerKg.toFixed(2)}€
-              </div>
-            </div>
-
-            <div className="bg-gradient-to-br from-orange-50 to-orange-100 border border-orange-200 rounded-xl p-6 text-center">
-              <div className="text-xs font-semibold text-orange-600 uppercase tracking-wide mb-2">
-                {language === 'el' ? 'Περιθώριο %' : 'Margin %'}
-              </div>
-              <div className="text-2xl font-bold text-slate-900">
-                {results.profitMargin.toFixed(1)}%
-              </div>
-            </div>
+            ))}
           </div>
 
           {/* Premium Results */}


### PR DESCRIPTION
## Summary
- replace the four-column grid in `ResultsSection` with a responsive flex layout
- ensure all summary boxes have gradient colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685c3c972fdc83288c432fd3aa500581