### PR TITLE
Add cost analysis components

### DIFF
--- a/src/components/CostAnalysisPanel.tsx
+++ b/src/components/CostAnalysisPanel.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import CostCard from './CostCard';
+import { costThresholds } from '@/config/costThresholds';
+
+export interface CostItem {
+  key: string;
+  value: number;
+}
+
+interface CostAnalysisPanelProps {
+  data: CostItem[];
+}
+
+const CostAnalysisPanel: React.FC<CostAnalysisPanelProps> = ({ data }) => {
+  const mapped = data.map((item) => {
+    const threshold = costThresholds[item.key];
+    return {
+      ...item,
+      label: threshold?.label || item.key,
+      tooltip: threshold?.tooltip || '',
+      minAllowed: threshold?.minAllowed ?? 0,
+      maxAllowed: threshold?.maxAllowed ?? Infinity,
+    };
+  });
+
+  const withinCount = mapped.filter(
+    (i) => i.value >= i.minAllowed && i.value <= i.maxAllowed
+  ).length;
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {mapped.map((item) => (
+          <CostCard
+            key={item.key}
+            label={item.label}
+            value={item.value}
+            minAllowed={item.minAllowed}
+            maxAllowed={item.maxAllowed}
+            tooltip={item.tooltip}
+          />
+        ))}
+      </div>
+      <p className="text-sm text-slate-600 mt-4">
+        {withinCount}/{mapped.length} within limits.
+      </p>
+    </div>
+  );
+};
+
+export default CostAnalysisPanel;

--- a/src/components/CostCard.tsx
+++ b/src/components/CostCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Info } from 'lucide-react';
+
+interface CostCardProps {
+  label: string;
+  value: number;
+  minAllowed: number;
+  maxAllowed: number;
+  tooltip: string;
+}
+
+const CostCard: React.FC<CostCardProps> = ({ label, value, minAllowed, maxAllowed, tooltip }) => {
+  let borderColor = 'border-l-green-600';
+  if (value < minAllowed) {
+    borderColor = 'border-l-yellow-600';
+  } else if (value > maxAllowed) {
+    borderColor = 'border-l-red-600';
+  }
+
+  return (
+    <Card className={`border-l-4 ${borderColor} shadow-sm`}>
+      <CardContent className="p-4 flex items-center justify-between">
+        <div className="flex items-center space-x-1">
+          <span className="font-medium text-slate-600">{label}</span>
+          {tooltip && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="w-4 h-4 text-slate-400 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-sm">{tooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
+        <span className="font-bold text-slate-900">{value.toFixed(2)}</span>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CostCard;

--- a/src/config/costThresholds.ts
+++ b/src/config/costThresholds.ts
@@ -1,0 +1,39 @@
+export interface CostThreshold {
+  label: string;
+  minAllowed: number;
+  maxAllowed: number;
+  tooltip: string;
+}
+
+export const costThresholds: Record<string, CostThreshold> = {
+  purchaseCost: {
+    label: 'Purchase Cost',
+    minAllowed: 0,
+    maxAllowed: 50,
+    tooltip: 'Expected cost of buying raw materials.'
+  },
+  laborCost: {
+    label: 'Labor Cost',
+    minAllowed: 0,
+    maxAllowed: 20,
+    tooltip: 'Wages and related expenses.'
+  },
+  packagingCost: {
+    label: 'Packaging Cost',
+    minAllowed: 0,
+    maxAllowed: 10,
+    tooltip: 'Packaging materials and supplies.'
+  },
+  transportCost: {
+    label: 'Transport Cost',
+    minAllowed: 0,
+    maxAllowed: 8,
+    tooltip: 'Delivery and logistics costs.'
+  },
+  additionalCosts: {
+    label: 'Other Costs',
+    minAllowed: 0,
+    maxAllowed: 12,
+    tooltip: 'Additional overhead expenses.'
+  }
+};


### PR DESCRIPTION
## Summary
- define basic cost thresholds
- add CostCard component with colored border and tooltip
- add CostAnalysisPanel that maps data to thresholds and shows summary

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1649a87483288ddd9633cb0f6a8a