### PR TITLE
Implement Vite-based docs and tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Αυτόματος Έλεγχος
+name: CI
 
 on:
   push:
@@ -7,12 +7,22 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npx eslint "src/**/*.{js,ts,tsx}" --max-warnings=0
+
+      - name: Build
+        run: npm run build
+
+      - name: Lighthouse CI
+        uses: lighthouse-ci/action@v2
         with:
-          node-version: '20'
-      - run: npm ci
-      - run: npm run build
+          configPath: .lighthouseci/config.js
+          uploadTarget: temporary-public-storage

--- a/.lighthouseci/config.js
+++ b/.lighthouseci/config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        "https://kostopro.vercel.app/",
+        "https://kostopro.vercel.app/about",
+        "https://kostopro.vercel.app/projects"
+      ],
+      startServerCommand: "npm run dev",
+      numberOfRuns: 3
+    },
+    assert: {
+      assertions: {
+        "categories:accessibility": ["error", { minScore: 0.9 }],
+        "categories:performance": ["warn", { minScore: 0.9 }]
+      }
+    },
+    upload: {
+      target: "temporary-public-storage"
+    }
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,73 +1,38 @@
-# Welcome to your Lovable project
+# kostopro
 
-## Project info
+A fast, Vite-powered React site deployed on Vercel.
 
-**URL**: https://lovable.dev/projects/02fe4c68-30d9-4122-a0a6-4ae9cf9eb90b
+## Getting Started
 
-## How can I edit this code?
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Run in dev mode
+   ```bash
+   npm run dev
+   ```
+3. Build for production
+   ```bash
+   npm run build
+   ```
+4. Deploy
+   Push to GitHub—Vercel will automatically pick up the project.
 
-There are several ways of editing your application.
+## Environment Variables
 
-**Use Lovable**
+`.env` (local only) and `.env.production` (Vercel)
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/02fe4c68-30d9-4122-a0a6-4ae9cf9eb90b) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
+```ini
+VITE_API_URL=https://api.example.com
 ```
 
-**Edit a file directly in GitHub**
+## Directory Structure
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
-
-**Use GitHub Codespaces**
-
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/02fe4c68-30d9-4122-a0a6-4ae9cf9eb90b) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+```
+src/
+├─ components/
+├─ hooks/
+├─ utils/
+└─ assets/
+```

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { colors, spacing, fontSizes } from "../../styles/design-tokens";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary";
+};
+
+export function Button({ variant = "primary", children, ...props }: ButtonProps) {
+  const bg = variant === "primary" ? colors.primary : colors.secondary;
+  return (
+    <button
+      style={{
+        backgroundColor: bg,
+        padding: spacing.md,
+        fontSize: fontSizes.base,
+        borderRadius: spacing.sm,
+        color: "#fff",
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/styles/design-tokens.ts
+++ b/src/styles/design-tokens.ts
@@ -1,0 +1,24 @@
+export const colors = {
+  primary: "#10B981",
+  secondary: "#3B82F6",
+  neutral: {
+    100: "#F3F4F6",
+    500: "#6B7280",
+    900: "#111827",
+  },
+};
+
+export const spacing = {
+  xs: "4px",
+  sm: "8px",
+  md: "16px",
+  lg: "24px",
+  xl: "32px",
+};
+
+export const fontSizes = {
+  sm: "0.875rem",
+  base: "1rem",
+  lg: "1.125rem",
+  xl: "1.25rem",
+};


### PR DESCRIPTION
## Summary
- document Vite setup in README
- add basic design tokens
- provide simple Button component using the tokens
- configure Lighthouse CI for accessibility testing
- run lint/build/Lighthouse in GitHub Actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d270d21148328911b55bc7107b618