### PR TITLE
Add Lighthouse CI config for local paths

### DIFF
--- a/.lighthouseci/config.js
+++ b/.lighthouseci/config.js
@@ -2,9 +2,9 @@ module.exports = {
   ci: {
     collect: {
       url: [
-        "https://kostopro.vercel.app/",
-        "https://kostopro.vercel.app/about",
-        "https://kostopro.vercel.app/projects"
+        "http://localhost:8080/",
+        "http://localhost:8080/about",
+        "http://localhost:8080/projects"
       ],
       startServerCommand: "npm run dev",
       numberOfRuns: 3
@@ -12,7 +12,7 @@ module.exports = {
     assert: {
       assertions: {
         "categories:accessibility": ["error", { minScore: 0.9 }],
-        "categories:performance": ["warn", { minScore: 0.9 }]
+        "categories:performance": ["error", { minScore: 0.9 }]
       }
     },
     upload: {


### PR DESCRIPTION
## Summary
- run Lighthouse CI on `/`, `/about`, `/projects` served from the local dev server
- enforce min score 90% on accessibility and performance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d2e02656883288a2606fa11d20d07