### PR TITLE
Configure CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
- run CI only on push to main

## Testing
- `npx eslint "src/**/*.{js,ts,tsx}" --max-warnings=0` *(fails: Cannot find package)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f5d87848328a30101f5891000bd