### PR TITLE
Add currency context and switcher

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,7 +23,7 @@ const Header: React.FC<HeaderProps> = ({
   showFileUpload,
   setShowFileUpload
 }) => {
-  const { language, setLanguage } = useLanguage();
+  const { language, setLanguage, currency, setCurrency } = useLanguage();
   const { user } = useAuth();
   const navigate = useNavigate();
   const { theme, setTheme } = useTheme();
@@ -134,6 +134,26 @@ const Header: React.FC<HeaderProps> = ({
                 className="h-8 px-3"
               >
                 EN
+              </Button>
+            </div>
+
+            {/* Currency Switcher */}
+            <div className="flex items-center space-x-2 bg-gray-100 rounded-lg p-1">
+              <Button
+                variant={currency === 'EUR' ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => setCurrency('EUR')}
+                className="h-8 px-3"
+              >
+                EUR
+              </Button>
+              <Button
+                variant={currency === 'USD' ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => setCurrency('USD')}
+                className="h-8 px-3"
+              >
+                USD
               </Button>
             </div>
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -4,6 +4,11 @@ import React, { createContext, useContext, useState } from 'react';
 interface LanguageContextType {
   language: 'el' | 'en';
   setLanguage: (lang: 'el' | 'en') => void;
+  /** Currently active currency */
+  currency: 'EUR' | 'USD';
+  setCurrency: (cur: 'EUR' | 'USD') => void;
+  /** Locale derived from the selected language */
+  locale: string;
   t: (key: string) => string;
 }
 
@@ -130,13 +135,16 @@ const translations = {
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [language, setLanguage] = useState<'el' | 'en'>('el');
+  const [currency, setCurrency] = useState<'EUR' | 'USD'>('EUR');
+
+  const locale = language === 'el' ? 'el-GR' : 'en-US';
 
   const t = (key: string): string => {
     return translations[language][key as keyof typeof translations[typeof language]] || key;
   };
 
   return (
-    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+    <LanguageContext.Provider value={{ language, setLanguage, currency, setCurrency, locale, t }}>
       {children}
     </LanguageContext.Provider>
   );

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,6 +1,8 @@
 
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
+import { useLanguage } from '@/contexts/LanguageContext';
+import React from 'react';
 
 export interface ExportData {
   [key: string]: any;
@@ -27,12 +29,18 @@ export const exportToPDF = async (elementId: string, filename: string = 'export'
   alert('PDF export functionality coming soon!');
 };
 
-export const formatCurrency = (amount: number, currency: string = 'EUR'): string => {
-  return new Intl.NumberFormat('el-GR', {
-    style: 'currency',
-    currency: currency
-  }).format(amount);
-};
+/**
+ * Returns a formatter that uses the active locale and currency from LanguageContext.
+ */
+export function useFormatCurrency() {
+  const { locale, currency } = useLanguage();
+
+  return React.useCallback(
+    (amount: number): string =>
+      new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount),
+    [locale, currency]
+  );
+}
 
 export const formatPercentage = (value: number): string => {
   return `${(value * 100).toFixed(2)}%`;


### PR DESCRIPTION
## Summary
- extend LanguageContext with currency and locale
- add currency toggle to the header
- implement `useFormatCurrency` hook that formats using active locale and currency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e540cd9bc8328b4febf57aa8eba41