### PR TITLE
Add cost forecasting helper and chart

### DIFF
--- a/src/components/AdvancedAnalysisTab.tsx
+++ b/src/components/AdvancedAnalysisTab.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import IntelligentPricing from './IntelligentPricing';
 import LaborOptimization from './LaborOptimization';
 import PackagingCalculator from './PackagingCalculator';
+import CostForecast from './CostForecast';
 
 interface AdvancedAnalysisTabProps {
   formData: any;
@@ -380,6 +381,7 @@ const AdvancedAnalysisTab: React.FC<AdvancedAnalysisTabProps> = ({ formData, upd
                   </div>
                 </CardContent>
               </Card>
+              <CostForecast />
             </div>
           )}
         </CardContent>

--- a/src/components/CostForecast.tsx
+++ b/src/components/CostForecast.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { useCostForecast, CostEntry } from '@/hooks/useCostForecast';
+
+const CostForecast: React.FC = () => {
+  const { history, setHistory, addEntry, forecast, calculateForecast } = useCostForecast();
+  const [newEntry, setNewEntry] = useState<{ date: string; cost: string }>({ date: '', cost: '' });
+  const [months, setMonths] = useState(6);
+
+  const handleAdd = () => {
+    const costNum = parseFloat(newEntry.cost);
+    if (!newEntry.date || isNaN(costNum)) return;
+    const entry: CostEntry = { date: newEntry.date, cost: costNum };
+    addEntry(entry);
+    setNewEntry({ date: '', cost: '' });
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const rows = text.split(/\r?\n/).filter(Boolean);
+    const parsed = rows
+      .map(row => {
+        const [d, c] = row.split(',');
+        const value = parseFloat(c);
+        if (!d || isNaN(value)) return null;
+        return { date: d.trim(), cost: value } as CostEntry;
+      })
+      .filter(Boolean) as CostEntry[];
+    if (parsed.length > 0) setHistory(parsed);
+  };
+
+  useEffect(() => {
+    calculateForecast(months, 'movingAverage');
+  }, [history, months, calculateForecast]);
+
+  const chartData = [
+    ...history.map(h => ({ label: h.date, cost: h.cost })),
+    ...forecast.map(f => ({ label: `M+${f.index}`, cost: f.value }))
+  ];
+
+  return (
+    <Card className="border-slate-200 shadow-lg">
+      <CardHeader className="bg-gradient-to-r from-orange-50 to-yellow-50 border-b border-slate-200">
+        <CardTitle className="text-slate-800">Cost Forecast</CardTitle>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        <div className="flex flex-wrap gap-2 items-end">
+          <Input
+            placeholder="YYYY-MM"
+            value={newEntry.date}
+            onChange={e => setNewEntry(prev => ({ ...prev, date: e.target.value }))}
+            className="w-32"
+          />
+          <Input
+            type="number"
+            placeholder="Cost"
+            value={newEntry.cost}
+            onChange={e => setNewEntry(prev => ({ ...prev, cost: e.target.value }))}
+            className="w-32"
+          />
+          <Button onClick={handleAdd}>Add</Button>
+          <div className="ml-auto flex items-center space-x-2">
+            <Input type="file" accept=".csv" onChange={handleFile} className="w-48" />
+            <Input
+              type="number"
+              value={months}
+              min={1}
+              onChange={e => setMonths(parseInt(e.target.value) || 1)}
+              className="w-20"
+            />
+          </div>
+        </div>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+              <XAxis dataKey="label" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="cost" stroke="#f97316" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CostForecast;

--- a/src/hooks/useCostForecast.ts
+++ b/src/hooks/useCostForecast.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from 'react';
+
+export interface CostEntry {
+  date: string;
+  cost: number;
+}
+
+export type ForecastMethod = 'movingAverage' | 'linearRegression';
+
+export interface ForecastEntry {
+  index: number;
+  value: number;
+}
+
+export const useCostForecast = (initial: CostEntry[] = []) => {
+  const [history, setHistory] = useState<CostEntry[]>(initial);
+  const [forecast, setForecast] = useState<ForecastEntry[]>([]);
+
+  const addEntry = useCallback((entry: CostEntry) => {
+    setHistory(prev => [...prev, entry]);
+  }, []);
+
+  const calculateForecast = useCallback(
+    (
+      months: number,
+      method: ForecastMethod = 'movingAverage',
+      windowSize = 3
+    ): ForecastEntry[] => {
+      if (history.length === 0 || months <= 0) {
+        setForecast([]);
+        return [];
+      }
+
+      let predicted: ForecastEntry[] = [];
+
+      if (method === 'movingAverage') {
+        const costs = history.map(h => h.cost);
+        for (let i = 0; i < months; i++) {
+          const start = Math.max(0, costs.length - windowSize);
+          const window = costs.slice(start);
+          const avg = window.reduce((a, b) => a + b, 0) / window.length;
+          predicted.push({ index: i + 1, value: avg });
+          costs.push(avg);
+        }
+      } else {
+        const n = history.length;
+        const xMean = (n - 1) / 2;
+        const yMean =
+          history.reduce((sum, h) => sum + h.cost, 0) / n;
+        const denom = history.reduce((sum, h, idx) => sum + Math.pow(idx - xMean, 2), 0) || 1;
+        const numer = history.reduce(
+          (sum, h, idx) => sum + (idx - xMean) * (h.cost - yMean),
+          0
+        );
+        const slope = numer / denom;
+        const intercept = yMean - slope * xMean;
+        for (let i = 0; i < months; i++) {
+          const x = n + i;
+          predicted.push({ index: i + 1, value: intercept + slope * x });
+        }
+      }
+
+      setForecast(predicted);
+      return predicted;
+    },
+    [history]
+  );
+
+  return { history, setHistory, addEntry, forecast, calculateForecast };
+};


### PR DESCRIPTION
## Summary
- implement `useCostForecast` hook for moving average/linear regression projections
- add `CostForecast` component for entering or uploading cost history and charting predictions
- show the new forecast chart in `AdvancedAnalysisTab`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e63919da88328873201c56a56c63f