### PR TITLE
Show persistent cost alerts

### DIFF
--- a/src/components/CostAnalysisPanel.tsx
+++ b/src/components/CostAnalysisPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import CostCard from './CostCard';
 import { costThresholds } from '@/config/costThresholds';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertTriangle } from 'lucide-react';
 
 export interface CostItem {
   key: string;
@@ -23,12 +25,31 @@ const CostAnalysisPanel: React.FC<CostAnalysisPanelProps> = ({ data }) => {
     };
   });
 
+  const exceeded = mapped.filter(
+    (i) => i.value > i.maxAllowed || i.value < i.minAllowed
+  );
+
   const withinCount = mapped.filter(
     (i) => i.value >= i.minAllowed && i.value <= i.maxAllowed
   ).length;
 
   return (
     <div>
+      {exceeded.map((item) => (
+        <Alert
+          key={item.key}
+          variant="destructive"
+          className="mb-4"
+        >
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>
+            {item.label} exceeds allowed range (max {item.maxAllowed}€)
+          </AlertTitle>
+          {item.tooltip && (
+            <AlertDescription>{item.tooltip}</AlertDescription>
+          )}
+        </Alert>
+      ))}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {mapped.map((item) => (
           <CostCard


### PR DESCRIPTION
## Summary
- warn when costs exceed allowed thresholds in CostAnalysisPanel
- show alerts in ResultsSection rather than toast notifications

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6392625883288c77ff92c4a91a12