### PR TITLE
Add export preview with theme options

### DIFF
--- a/src/components/DataExport.tsx
+++ b/src/components/DataExport.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
 import { exportToXLSX, exportToCSV } from '@/utils/exportUtils';
 import { useLanguage } from '@/contexts/LanguageContext';
+import ExportPreview from './ExportPreview';
 
 interface DataExportProps {
   results: any;
@@ -12,8 +13,27 @@ interface DataExportProps {
 
 const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
   const { language } = useLanguage();
+  const [template, setTemplate] = useState<'classic' | 'modern' | 'minimal'>('classic');
+
+  const templates = {
+    classic: { font: "'Times New Roman', serif", bg: '#fff', color: '#333' },
+    modern: { font: 'Arial, sans-serif', bg: '#f9fafb', color: '#1f2937' },
+    minimal: { font: 'Helvetica, sans-serif', bg: '#fff', color: '#374151' }
+  } as const;
 
   const buildDataset = () => [{ ...formData, ...results }];
+
+  const buildHtml = () => {
+    const t = templates[template];
+    const data = buildDataset();
+    const headers = Object.keys(data[0] || {});
+    const rows = data
+      .map(row => `<tr>${headers.map(h => `<td>${row[h] ?? ''}</td>`).join('')}</tr>`)
+      .join('');
+    return `<!DOCTYPE html><html><head><style>body{font-family:${t.font};background:${t.bg};color:${t.color};margin:20px;}table{width:100%;border-collapse:collapse;}td,th{border:1px solid #ccc;padding:4px;text-align:left;}</style></head><body><table><thead><tr>${headers.map(h => `<th>${h}</th>`).join('')}</tr></thead><tbody>${rows}</tbody></table></body></html>`;
+  };
+
+  const previewHtml = useMemo(buildHtml, [results, formData, template]);
 
   const handleExportXLSX = () => {
     exportToXLSX(buildDataset(), 'kostopro_results');
@@ -32,16 +52,18 @@ const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="flex space-x-2">
-          <Button onClick={handleExportXLSX} className="w-full" size="lg">
-            <Download className="w-4 h-4 mr-2" />
-            {language === 'el' ? 'Λήψη Excel' : 'Download Excel'}
-          </Button>
-          <Button onClick={handleExportCSV} className="w-full" size="lg" variant="secondary">
-            <Download className="w-4 h-4 mr-2" />
-            {language === 'el' ? 'Λήψη CSV' : 'Download CSV'}
-          </Button>
-        </div>
+        <ExportPreview preview={previewHtml} theme={template} onThemeChange={setTemplate}>
+          <div className="flex space-x-2">
+            <Button onClick={handleExportXLSX} className="w-full" size="lg">
+              <Download className="w-4 h-4 mr-2" />
+              {language === 'el' ? 'Λήψη Excel' : 'Download Excel'}
+            </Button>
+            <Button onClick={handleExportCSV} className="w-full" size="lg" variant="secondary">
+              <Download className="w-4 h-4 mr-2" />
+              {language === 'el' ? 'Λήψη CSV' : 'Download CSV'}
+            </Button>
+          </div>
+        </ExportPreview>
       </CardContent>
     </Card>
   );

--- a/src/components/ExportPreview.tsx
+++ b/src/components/ExportPreview.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface ExportPreviewProps {
+  preview: string;
+  theme: 'classic' | 'modern' | 'minimal';
+  onThemeChange: (theme: 'classic' | 'modern' | 'minimal') => void;
+  children: React.ReactNode;
+}
+
+const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, theme, onThemeChange, children }) => {
+  return (
+    <div className="flex flex-col lg:flex-row gap-4">
+      <div className="lg:w-1/2 space-y-4">
+        {children}
+        <div>
+          <label htmlFor="template" className="block text-sm font-medium mb-1">Template</label>
+          <select
+            id="template"
+            value={theme}
+            onChange={e => onThemeChange(e.target.value as 'classic' | 'modern' | 'minimal')}
+            className="w-full border rounded p-2"
+          >
+            <option value="classic">Classic</option>
+            <option value="modern">Modern</option>
+            <option value="minimal">Minimal</option>
+          </select>
+        </div>
+      </div>
+      <div className="lg:w-1/2 border rounded bg-white h-96 overflow-hidden">
+        <iframe title="preview" className="w-full h-full" srcDoc={preview} />
+      </div>
+    </div>
+  );
+};
+
+export default ExportPreview;

--- a/src/components/PDFExport.tsx
+++ b/src/components/PDFExport.tsx
@@ -1,322 +1,105 @@
-
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { FileText, Download, BarChart3, PieChart, TrendingUp } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { toast } from 'sonner';
+import ExportPreview from './ExportPreview';
 
 interface PDFExportProps {
   results: any;
   formData: any;
 }
 
+type Template = 'classic' | 'modern' | 'minimal';
+
+const templates = {
+  classic: {
+    font: "'Times New Roman', serif",
+    background: '#ffffff',
+    text: '#333333',
+    headerBg: '#003366',
+    headerColor: '#ffffff',
+    logo: 'KostoPro'
+  },
+  modern: {
+    font: 'Arial, sans-serif',
+    background: '#f9fafb',
+    text: '#1f2937',
+    headerBg: '#4f46e5',
+    headerColor: '#ffffff',
+    logo: 'KostoPro'
+  },
+  minimal: {
+    font: 'Helvetica, sans-serif',
+    background: '#ffffff',
+    text: '#374151',
+    headerBg: '#ffffff',
+    headerColor: '#111827',
+    logo: 'KostoPro'
+  }
+} as const;
+
 const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
   const { language } = useLanguage();
   const [selectedCharts, setSelectedCharts] = useState({
     costBreakdown: true,
     profitAnalysis: true,
-    competitorComparison: false,
-    financialForecast: false
+    competitorComparison: false
   });
+  const [template, setTemplate] = useState<Template>('classic');
+
+  const buildHtmlContent = () => {
+    const t = templates[template];
+    const title = language === 'el' ? 'Αναφορά Κοστολόγησης' : 'Costing Report';
+    const productLabel = language === 'el' ? 'Προϊόν:' : 'Product:';
+    const dateLabel = language === 'el' ? 'Ημερομηνία:' : 'Date:';
+    const resultsLabel = language === 'el' ? 'Αποτελέσματα' : 'Results';
+    const costAnalysisLabel = language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Analysis';
+
+    const chartSections: string[] = [];
+    if (selectedCharts.costBreakdown) {
+      chartSections.push(`
+        <div class="section">
+          <h2>${language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Breakdown'}</h2>
+        </div>
+      `);
+    }
+    if (selectedCharts.profitAnalysis) {
+      chartSections.push(`
+        <div class="section">
+          <h2>${language === 'el' ? 'Ανάλυση Κερδοφορίας' : 'Profitability Analysis'}</h2>
+        </div>
+      `);
+    }
+
+    const themeCSS = `
+      body { font-family: ${t.font}; background: ${t.background}; color: ${t.text}; margin:20px; }
+      .header { background: ${t.headerBg}; color:${t.headerColor}; text-align:center; padding:20px; }
+    `;
+
+    return `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>${title}</title><style>${themeCSS}
+      .section{margin-bottom:20px}
+    </style></head><body>
+      <div class="header"><div>${t.logo}</div><h1>${title}</h1>
+        <p><strong>${productLabel}</strong> ${formData.productName || ''}</p>
+        <p><strong>${dateLabel}</strong> ${new Date().toLocaleDateString()}</p>
+      </div>
+      <div class="section"><h2>${resultsLabel}</h2>
+        <p>${language === 'el' ? 'Συνολικό Κόστος' : 'Total Cost'}: ${results?.totalCost?.toFixed(2) || 0}€</p>
+        <p>${language === 'el' ? 'Τιμή Πώλησης' : 'Selling Price'}: ${results?.sellingPrice?.toFixed(2) || 0}€</p>
+      </div>
+      <div class="section"><h2>${costAnalysisLabel}</h2></div>
+      ${chartSections.join('')}
+    </body></html>`;
+  };
+
+  const previewHtml = useMemo(buildHtmlContent, [results, formData, template, selectedCharts, language]);
 
   const exportToPDF = async () => {
     try {
-      const title = language === 'el' ? 'Αναφορά Κοστολόγησης' : 'Costing Report';
-      const productLabel = language === 'el' ? 'Προϊόν:' : 'Product:';
-      const dateLabel = language === 'el' ? 'Ημερομηνία:' : 'Date:';
-      const basicDataLabel = language === 'el' ? 'Βασικά Στοιχεία' : 'Basic Data';
-      const resultsLabel = language === 'el' ? 'Αποτελέσματα' : 'Results';
-      const costAnalysisLabel = language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Analysis';
-      const summaryLabel = language === 'el' ? 'Περίληψη με Βασικά Σημεία' : 'Summary with Key Points';
-      const keyPointsLabel = language === 'el' ? 'Βασικά Σημεία:' : 'Key Points:';
-      
-      // Generate chart sections if selected
-      const chartSections = [];
-      
-      if (selectedCharts.costBreakdown) {
-        chartSections.push(`
-          <div class="section">
-            <h2>${language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Breakdown'}</h2>
-            <div class="chart-explanation">
-              <p>${language === 'el' 
-                ? 'Το γράφημα δείχνει την κατανομή των κοστών ανά κατηγορία. Το μεγαλύτερο κόστος προέρχεται από την αγορά πρώτων υλών.'
-                : 'The chart shows cost distribution by category. The largest cost comes from raw material purchase.'
-              }</p>
-            </div>
-          </div>
-        `);
-      }
-
-      if (selectedCharts.profitAnalysis) {
-        chartSections.push(`
-          <div class="section">
-            <h2>${language === 'el' ? 'Ανάλυση Κερδοφορίας' : 'Profitability Analysis'}</h2>
-            <div class="chart-explanation">
-              <p>${language === 'el' 
-                ? 'Η ανάλυση δείχνει το περιθώριο κέρδους και τη σχέση κόστους-εσόδων. Υψηλότερο περιθώριο σημαίνει καλύτερη κερδοφορία.'
-                : 'The analysis shows profit margin and cost-revenue relationship. Higher margin means better profitability.'
-              }</p>
-            </div>
-          </div>
-        `);
-      }
-
-      // Create comprehensive HTML content for PDF
-      const htmlContent = `
-        <!DOCTYPE html>
-        <html>
-        <head>
-          <meta charset="UTF-8">
-          <title>${title}</title>
-          <style>
-            body { 
-              font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-              margin: 20px; 
-              line-height: 1.6;
-              color: #333;
-            }
-            .header { 
-              text-align: center; 
-              margin-bottom: 40px; 
-              border-bottom: 2px solid #3b82f6;
-              padding-bottom: 20px;
-            }
-            .header h1 {
-              color: #1e40af;
-              margin-bottom: 10px;
-            }
-            .section { 
-              margin-bottom: 30px; 
-              background: #f8fafc;
-              padding: 20px;
-              border-radius: 8px;
-              border-left: 4px solid #3b82f6;
-            }
-            .section h2 {
-              color: #1e40af;
-              margin-bottom: 15px;
-              font-size: 1.2em;
-            }
-            .grid { 
-              display: grid; 
-              grid-template-columns: 1fr 1fr; 
-              gap: 20px; 
-              margin-bottom: 20px;
-            }
-            .cost-item { 
-              display: flex; 
-              justify-content: space-between; 
-              margin: 8px 0; 
-              padding: 8px;
-              background: white;
-              border-radius: 4px;
-            }
-            .cost-item strong {
-              color: #1e40af;
-            }
-            .result-box { 
-              background: #f0f9ff; 
-              padding: 20px; 
-              margin: 15px 0; 
-              border-radius: 8px; 
-              border: 1px solid #bae6fd;
-            }
-            .result-box h3 {
-              color: #0c4a6e;
-              margin-bottom: 10px;
-            }
-            .highlight {
-              background: linear-gradient(135deg, #3b82f6, #1d4ed8);
-              color: white;
-              padding: 15px;
-              border-radius: 8px;
-              text-align: center;
-              margin: 10px 0;
-            }
-            .summary {
-              background: #f0fdf4;
-              border: 1px solid #bbf7d0;
-              padding: 20px;
-              border-radius: 8px;
-              margin-top: 20px;
-            }
-            .summary h3 {
-              color: #15803d;
-              margin-bottom: 15px;
-            }
-            .summary ul {
-              margin: 10px 0;
-              padding-left: 20px;
-            }
-            .summary li {
-              margin: 8px 0;
-              line-height: 1.5;
-            }
-            .chart-explanation {
-              background: #fef3c7;
-              border: 1px solid #fcd34d;
-              padding: 15px;
-              border-radius: 6px;
-              margin-top: 15px;
-            }
-            .footer {
-              margin-top: 40px;
-              text-align: center;
-              color: #64748b;
-              font-size: 0.9em;
-              border-top: 1px solid #e2e8f0;
-              padding-top: 20px;
-            }
-            .key-points {
-              background: #eff6ff;
-              border: 1px solid #bfdbfe;
-              padding: 20px;
-              border-radius: 8px;
-              margin: 20px 0;
-            }
-            .key-points h4 {
-              color: #1e40af;
-              margin-bottom: 10px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="header">
-            <h1>${title}</h1>
-            <p><strong>${productLabel}</strong> ${formData.productName || (language === 'el' ? 'Μη καθορισμένο' : 'Not specified')}</p>
-            <p><strong>${dateLabel}</strong> ${new Date().toLocaleDateString(language === 'el' ? 'el-GR' : 'en-US')}</p>
-          </div>
-          
-          <div class="summary">
-            <h3>${summaryLabel}</h3>
-            <div class="key-points">
-              <h4>${keyPointsLabel}</h4>
-              <ul>
-                <li><strong>${language === 'el' ? 'Υπολογισμός ρυθμού ανάπτυξης:' : 'Growth rate calculation:'}</strong> ${language === 'el' 
-                  ? 'Ο υπολογισμός γίνεται με τον τύπο: (Τελική Αξία / Αρχική Αξία) - 1. Απαιτούνται η τελική και η αρχική τιμή για τον υπολογισμό του ποσοστού ανάπτυξης.'
-                  : 'Calculated using: (Final Value / Initial Value) - 1. Requires final and initial values to calculate growth percentage.'
-                }</li>
-                <li><strong>${language === 'el' ? 'Επενδυτική στρατηγική:' : 'Investment strategy:'}</strong> ${language === 'el' 
-                  ? 'Λήψη επενδυτικών αποφάσεων με βάση τον υπολογισμό του ποσοστού ανάπτυξης και την ανάλυση κινδύνου.'
-                  : 'Making investment decisions based on growth rate calculation and risk analysis.'
-                }</li>
-                <li><strong>${language === 'el' ? 'Παρούσα Αξία (PV):' : 'Present Value (PV):'}</strong> ${language === 'el' 
-                  ? 'Διερευνάται η έννοια της παρούσας αξίας για την αξιολόγηση επενδυτικών επιλογών.'
-                  : 'Exploring the concept of present value to evaluate investment options.'
-                }</li>
-                <li><strong>${language === 'el' ? 'Κόστος Ευκαιρίας:' : 'Opportunity Cost:'}</strong> ${language === 'el' 
-                  ? 'Η απόδοση που χάνετε επιλέγοντας μια επένδυση αντί για την καλύτερη εναλλακτική.'
-                  : 'The return you give up by choosing one investment over the best alternative.'
-                }</li>
-                <li><strong>${language === 'el' ? 'Ανάλυση Νεκρού Σημείου:' : 'Break-even Analysis:'}</strong> ${language === 'el' 
-                  ? 'Δείχνει εύκολα την ποσότητα που απαιτείται για να καλύψει το σταθερό κόστος.'
-                  : 'Easily shows the quantity required to cover fixed costs.'
-                }</li>
-              </ul>
-            </div>
-          </div>
-          
-          <div class="section">
-            <h2>${basicDataLabel}</h2>
-            <div class="grid">
-              <div class="cost-item">
-                <span>${language === 'el' ? 'Τιμή Αγοράς:' : 'Purchase Price:'}</span>
-                <strong>${formData.purchasePrice || 0}€/${language === 'el' ? 'κιλό' : 'kg'}</strong>
-              </div>
-              <div class="cost-item">
-                <span>${language === 'el' ? 'Ποσότητα:' : 'Quantity:'}</span>
-                <strong>${formData.quantity || 0} ${language === 'el' ? 'κιλά' : 'kg'}</strong>
-              </div>
-              <div class="cost-item">
-                <span>${language === 'el' ? 'Απώλεια:' : 'Waste:'}</span>
-                <strong>${formData.waste || 0}%</strong>
-              </div>
-              <div class="cost-item">
-                <span>${language === 'el' ? 'Ποσοστό Γλασσαρίσματος:' : 'Glazing Percentage:'}</span>
-                <strong>${formData.glazingPercent || 0}%</strong>
-              </div>
-              <div class="cost-item">
-                <span>${language === 'el' ? 'ΦΠΑ:' : 'VAT:'}</span>
-                <strong>${formData.vatPercent || 0}%</strong>
-              </div>
-              <div class="cost-item">
-                <span>${language === 'el' ? 'Περιθώριο Κέρδους:' : 'Profit Margin:'}</span>
-                <strong>${formData.profitMargin || 0}%</strong>
-              </div>
-            </div>
-          </div>
-
-          <div class="section">
-            <h2>${resultsLabel}</h2>
-            <div class="grid">
-              <div class="result-box">
-                <h3>${language === 'el' ? 'Συνολικό Κόστος' : 'Total Cost'}</h3>
-                <div class="highlight">
-                  <span style="font-size: 24px; font-weight: bold;">${results?.totalCost?.toFixed(2) || 0}€</span>
-                </div>
-              </div>
-              <div class="result-box">
-                <h3>${language === 'el' ? 'Τιμή Πώλησης' : 'Selling Price'}</h3>
-                <div class="highlight">
-                  <span style="font-size: 24px; font-weight: bold;">${results?.sellingPrice?.toFixed(2) || 0}€/${language === 'el' ? 'κιλό' : 'kg'}</span>
-                </div>
-              </div>
-              <div class="result-box">
-                <h3>${language === 'el' ? 'Κέρδος ανά Κιλό' : 'Profit per Kg'}</h3>
-                <div class="highlight">
-                  <span style="font-size: 24px; font-weight: bold;">${results?.profitPerKg?.toFixed(2) || 0}€</span>
-                </div>
-              </div>
-              <div class="result-box">
-                <h3>${language === 'el' ? 'Καθαρό Βάρος' : 'Net Weight'}</h3>
-                <div class="highlight">
-                  <span style="font-size: 24px; font-weight: bold;">${results?.netWeight?.toFixed(2) || 0} ${language === 'el' ? 'κιλά' : 'kg'}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="section">
-            <h2>${costAnalysisLabel}</h2>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'Κόστος Αγοράς:' : 'Purchase Cost:'}</span>
-              <strong>${results?.purchaseCost?.toFixed(2) || 0}€</strong>
-            </div>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'Κόστος Εργασίας:' : 'Labor Cost:'}</span>
-              <strong>${results?.laborCost?.toFixed(2) || 0}€</strong>
-            </div>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'Κόστος Συσκευασίας:' : 'Packaging Cost:'}</span>
-              <strong>${results?.packagingCost?.toFixed(2) || 0}€</strong>
-            </div>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'Κόστος Μεταφοράς:' : 'Transport Cost:'}</span>
-              <strong>${results?.transportCost?.toFixed(2) || 0}€</strong>
-            </div>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'Επιπλέον Κόστη:' : 'Additional Costs:'}</span>
-              <strong>${results?.additionalCosts?.toFixed(2) || 0}€</strong>
-            </div>
-            <div class="cost-item">
-              <span>${language === 'el' ? 'ΦΠΑ:' : 'VAT:'}</span>
-              <strong>${results?.vatAmount?.toFixed(2) || 0}€</strong>
-            </div>
-          </div>
-
-          ${chartSections.join('')}
-
-          <div class="footer">
-            <p>${language === 'el' ? 'Αναφορά παραχθείσα από τον Υπολογιστή Κόστους Pro' : 'Report generated by Cost Calculator Pro'}</p>
-            <p>Design by Alexandros Kopanakis</p>
-          </div>
-        </body>
-        </html>
-      `;
-
-      // Create blob and download
+      const htmlContent = buildHtmlContent();
       const blob = new Blob([htmlContent], { type: 'text/html' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -326,18 +109,9 @@ const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-
-      toast.success(
-        language === 'el' 
-          ? 'Η αναφορά εξήχθη επιτυχώς!' 
-          : 'Report exported successfully!'
-      );
-    } catch (error) {
-      toast.error(
-        language === 'el' 
-          ? 'Σφάλμα κατά την εξαγωγή του PDF' 
-          : 'Error exporting PDF'
-      );
+      toast.success(language === 'el' ? 'Η αναφορά εξήχθη επιτυχώς!' : 'Report exported successfully!');
+    } catch (err) {
+      toast.error(language === 'el' ? 'Σφάλμα κατά την εξαγωγή του PDF' : 'Error exporting PDF');
     }
   };
 
@@ -350,60 +124,52 @@ const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
         </CardTitle>
       </CardHeader>
       <CardContent className="p-6 space-y-4">
-        <div className="space-y-3">
-          <h4 className="font-semibold text-sm">
-            {language === 'el' ? 'Επιλέξτε γραφήματα για εξαγωγή:' : 'Select charts to export:'}
-          </h4>
-          
-          <div className="space-y-2">
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="costBreakdown"
-                checked={selectedCharts.costBreakdown}
-                onCheckedChange={(checked) => 
-                  setSelectedCharts(prev => ({ ...prev, costBreakdown: checked as boolean }))
-                }
-              />
-              <label htmlFor="costBreakdown" className="text-sm flex items-center space-x-2">
-                <BarChart3 className="w-4 h-4" />
-                <span>{language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Breakdown'}</span>
-              </label>
+        <ExportPreview preview={previewHtml} theme={template} onThemeChange={setTemplate}>
+          <div className="space-y-3">
+            <h4 className="font-semibold text-sm">
+              {language === 'el' ? 'Επιλέξτε γραφήματα για εξαγωγή:' : 'Select charts to export:'}
+            </h4>
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="costBreakdown"
+                  checked={selectedCharts.costBreakdown}
+                  onCheckedChange={(checked) => setSelectedCharts(prev => ({ ...prev, costBreakdown: checked as boolean }))}
+                />
+                <label htmlFor="costBreakdown" className="text-sm flex items-center space-x-2">
+                  <BarChart3 className="w-4 h-4" />
+                  <span>{language === 'el' ? 'Ανάλυση Κόστους' : 'Cost Breakdown'}</span>
+                </label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="profitAnalysis"
+                  checked={selectedCharts.profitAnalysis}
+                  onCheckedChange={(checked) => setSelectedCharts(prev => ({ ...prev, profitAnalysis: checked as boolean }))}
+                />
+                <label htmlFor="profitAnalysis" className="text-sm flex items-center space-x-2">
+                  <TrendingUp className="w-4 h-4" />
+                  <span>{language === 'el' ? 'Ανάλυση Κερδοφορίας' : 'Profitability Analysis'}</span>
+                </label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="competitorComparison"
+                  checked={selectedCharts.competitorComparison}
+                  onCheckedChange={(checked) => setSelectedCharts(prev => ({ ...prev, competitorComparison: checked as boolean }))}
+                />
+                <label htmlFor="competitorComparison" className="text-sm flex items-center space-x-2">
+                  <PieChart className="w-4 h-4" />
+                  <span>{language === 'el' ? 'Σύγκριση Ανταγωνισμού' : 'Competitor Comparison'}</span>
+                </label>
+              </div>
             </div>
-
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="profitAnalysis"
-                checked={selectedCharts.profitAnalysis}
-                onCheckedChange={(checked) => 
-                  setSelectedCharts(prev => ({ ...prev, profitAnalysis: checked as boolean }))
-                }
-              />
-              <label htmlFor="profitAnalysis" className="text-sm flex items-center space-x-2">
-                <TrendingUp className="w-4 h-4" />
-                <span>{language === 'el' ? 'Ανάλυση Κερδοφορίας' : 'Profitability Analysis'}</span>
-              </label>
-            </div>
-
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="competitorComparison"
-                checked={selectedCharts.competitorComparison}
-                onCheckedChange={(checked) => 
-                  setSelectedCharts(prev => ({ ...prev, competitorComparison: checked as boolean }))
-                }
-              />
-              <label htmlFor="competitorComparison" className="text-sm flex items-center space-x-2">
-                <PieChart className="w-4 h-4" />
-                <span>{language === 'el' ? 'Σύγκριση Ανταγωνισμού' : 'Competitor Comparison'}</span>
-              </label>
-            </div>
+            <Button onClick={exportToPDF} className="w-full" size="lg">
+              <Download className="w-4 h-4 mr-2" />
+              {language === 'el' ? 'Εξαγωγή Αναφοράς' : 'Export Report'}
+            </Button>
           </div>
-        </div>
-
-        <Button onClick={exportToPDF} className="w-full" size="lg">
-          <Download className="w-4 h-4 mr-2" />
-          {language === 'el' ? 'Εξαγωγή Αναφοράς' : 'Export Report'}
-        </Button>
+        </ExportPreview>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add new `ExportPreview` component for split-view export configuration and live preview
- integrate `ExportPreview` into `PDFExport` and `DataExport`
- support Classic, Modern and Minimal templates for previews and exports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e78253b6c8328abff3a9dd71cda5a