### PR TITLE
Add snapshot export option

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
     "file-saver": "^2.0.5",
+    "html2canvas": "^1.4.1",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/DataExport.tsx
+++ b/src/components/DataExport.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Download } from 'lucide-react';
-import { exportToXLSX, exportToCSV } from '@/utils/exportUtils';
+import { Download, Image } from 'lucide-react';
+import { exportToXLSX, exportToCSV, exportElementToPNG } from '@/utils/exportUtils';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 interface DataExportProps {
@@ -23,6 +23,10 @@ const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
     exportToCSV(buildDataset(), 'kostopro_results');
   };
 
+  const handleExportPNG = () => {
+    exportElementToPNG('report-preview', 'kostopro_snapshot');
+  };
+
   return (
     <Card className="shadow-lg">
       <CardHeader>
@@ -40,6 +44,10 @@ const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
           <Button onClick={handleExportCSV} className="w-full" size="lg" variant="secondary">
             <Download className="w-4 h-4 mr-2" />
             {language === 'el' ? 'Λήψη CSV' : 'Download CSV'}
+          </Button>
+          <Button onClick={handleExportPNG} className="w-full" size="lg" variant="outline">
+            <Image className="w-4 h-4 mr-2" />
+            {language === 'el' ? 'Στιγμιότυπο' : 'Snapshot Export'}
           </Button>
         </div>
       </CardContent>

--- a/src/components/ResultsSection.tsx
+++ b/src/components/ResultsSection.tsx
@@ -174,7 +174,7 @@ const ResultsSection: React.FC<ResultsSectionProps> = ({
   ].filter(item => item.value > 0);
 
   return (
-    <div className="space-y-6 animate-in slide-in-from-bottom-4 duration-500">
+    <div id="report-preview" className="space-y-6 animate-in slide-in-from-bottom-4 duration-500">
       {exceededCosts.map((item) => (
         <Alert key={item.key} variant="destructive">
           <AlertTriangle className="h-4 w-4" />

--- a/src/types/html2canvas.d.ts
+++ b/src/types/html2canvas.d.ts
@@ -1,0 +1,1 @@
+declare module 'html2canvas';

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -37,6 +37,22 @@ export const exportToPDF = async (elementId: string, filename: string = 'export'
   alert('PDF export functionality coming soon!');
 };
 
+export const exportElementToPNG = async (
+  elementId: string,
+  filename: string = 'snapshot'
+) => {
+  const html2canvas = (await import('html2canvas')).default;
+  const element = document.getElementById(elementId);
+  if (!element) {
+    console.error('Element not found:', elementId);
+    return;
+  }
+  const canvas = await html2canvas(element as HTMLElement);
+  canvas.toBlob((blob) => {
+    if (blob) saveAs(blob, `${filename}.png`);
+  });
+};
+
 /**
  * Returns a formatter that uses the active locale and currency from LanguageContext.
  */


### PR DESCRIPTION
## Summary
- add html2canvas dependency
- implement `exportElementToPNG` helper
- add snapshot export button
- mark results section with `report-preview` id
- provide module declaration for html2canvas

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7823542883289ce98bbcd4d844dd