### PR TITLE
Improve Excel export field picker

### DIFF
--- a/src/components/DataExport.tsx
+++ b/src/components/DataExport.tsx
@@ -6,6 +6,9 @@ import { exportToXLSX, exportToCSV, exportElementToPNG } from '@/utils/exportUti
 import { useLanguage } from '@/contexts/LanguageContext';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
 import ExportPreview from './ExportPreview';
 
 interface DataExportProps {
@@ -33,6 +36,22 @@ const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
 
   // Κατάσταση επιλεγμένων πεδίων
   const [selectedFields, setSelectedFields] = useState<Record<string, boolean>>({});
+
+  const handleSelectAll = () => {
+    const all: Record<string, boolean> = {};
+    availableFields.forEach((f) => {
+      all[f] = true;
+    });
+    setSelectedFields(all);
+  };
+
+  const handleClear = () => {
+    const none: Record<string, boolean> = {};
+    availableFields.forEach((f) => {
+      none[f] = false;
+    });
+    setSelectedFields(none);
+  };
 
   useEffect(() => {
     const defaults: Record<string, boolean> = {};
@@ -98,20 +117,51 @@ const DataExport: React.FC<DataExportProps> = ({ results, formData }) => {
       <CardContent className="p-6 space-y-4">
         {/* Επιλογή πεδίων για εξαγωγή */}
         <div className="space-y-2 pb-2">
-          {availableFields.map((field) => (
-            <div key={field} className="flex items-center space-x-2">
-              <Checkbox
-                id={field}
-                checked={selectedFields[field]}
-                onCheckedChange={(checked) =>
-                  setSelectedFields((prev) => ({ ...prev, [field]: checked as boolean }))
-                }
-              />
-              <Label htmlFor={field} className="text-sm cursor-pointer">
-                {t?.(field) || field}
-              </Label>
-            </div>
-          ))}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm">
+                {language === 'el' ? 'Επιλογή Πεδίων' : 'Select Fields'}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-60 p-2">
+              <div className="flex justify-between text-xs mb-2">
+                <button onClick={handleSelectAll} className="underline">
+                  {language === 'el' ? 'Επιλογή όλων' : 'Select All'}
+                </button>
+                <button onClick={handleClear} className="underline">
+                  {language === 'el' ? 'Καθαρισμός' : 'Clear'}
+                </button>
+              </div>
+              <ScrollArea className="max-h-[300px] pr-2">
+                <div className="space-y-2">
+                  {availableFields.map((field) => (
+                    <div key={field} className="flex items-center space-x-2 text-sm">
+                      <Checkbox
+                        id={field}
+                        checked={selectedFields[field]}
+                        onCheckedChange={(checked) =>
+                          setSelectedFields((prev) => ({ ...prev, [field]: checked as boolean }))
+                        }
+                      />
+                      <Label htmlFor={field} className="cursor-pointer">
+                        {t?.(field) || field}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            </PopoverContent>
+          </Popover>
+
+          <div className="flex flex-wrap gap-1 mt-2">
+            {Object.keys(selectedFields)
+              .filter((f) => selectedFields[f])
+              .map((f) => (
+                <Badge key={f} variant="secondary" className="text-xs">
+                  {t?.(f) || f}
+                </Badge>
+              ))}
+          </div>
         </div>
 
         <ExportPreview preview={previewHtml} theme={template} onThemeChange={setTemplate}>


### PR DESCRIPTION
## Summary
- refine DataExport fields selection
- use popover with scrollable checkbox list and select all/clear buttons
- show selected fields as small badges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.app.json` *(fails with compile errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685e856fd8108328b931443e1b19bf19