### PR TITLE
Add onboarding tour integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const NotFound = React.lazy(() => import("./pages/NotFound"));
 import { LanguageProvider } from './contexts/LanguageContext';
 import { AuthProvider } from './contexts/AuthContext';
 import ErrorBoundary from './components/ErrorBoundary';
+import OnboardingTour from './components/OnboardingTour';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,6 +35,7 @@ function App() {
               <Toaster />
               <Sonner />
               <BrowserRouter>
+                <OnboardingTour />
                 <Suspense fallback={<LoadingSkeleton />}>
                   <Routes>
                     <Route path="/" element={<Index />} />

--- a/src/components/MainTabs.tsx
+++ b/src/components/MainTabs.tsx
@@ -106,7 +106,7 @@ const MainTabs: React.FC<MainTabsProps> = ({
               />
             </TabsContent>
 
-            <TabsContent value="batches" className="mt-0">
+            <TabsContent value="batches" className="mt-0" data-tour="batch">
               <BatchManagement />
             </TabsContent>
 

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -13,6 +13,10 @@ const steps = [
   {
     target: '[data-tour="export"]',
     content: 'Χρησιμοποιήστε αυτές τις επιλογές για να κάνετε εξαγωγή.'
+  },
+  {
+    target: '[data-tour="batch"]',
+    content: 'Διαχειριστείτε τις παρτίδες σας εδώ.'
   }
 ];
 


### PR DESCRIPTION
## Summary
- extend `OnboardingTour` with a step for Batch Management
- mark Batch Management tab with `data-tour` attribute
- run the tour from `App` for new users

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eab786668832896e0cc7655d376e3