### PR TITLE
Use translation keys for EmptyState

### DIFF
--- a/src/components/BatchManagement.tsx
+++ b/src/components/BatchManagement.tsx
@@ -512,11 +512,7 @@ const BatchManagement = () => {
                   <tr>
                     <td colSpan={8}>
                       <EmptyState
-                        message={
-                          language === "el"
-                            ? "Δεν υπάρχουν παρτίδες"
-                            : "No batches available"
-                        }
+                        messageKey="batches.empty"
                         icon={
                           <Package className="w-8 h-8 mb-2 text-gray-400" />
                         }

--- a/src/components/CostAnalysisPanel.tsx
+++ b/src/components/CostAnalysisPanel.tsx
@@ -48,7 +48,7 @@ const CostAnalysisPanel: React.FC<CostAnalysisPanelProps> = ({ data }) => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {mapped.length === 0 && (
           <EmptyState
-            message="Δεν υπάρχουν δεδομένα κόστους"
+            messageKey="costs.empty"
             icon={<AlertTriangle className="w-8 h-8 mb-2 text-gray-400" />}
           />
         )}

--- a/src/components/ProcessingPhases.tsx
+++ b/src/components/ProcessingPhases.tsx
@@ -115,11 +115,7 @@ const ProcessingPhases: React.FC<ProcessingPhasesProps> = ({
         <div className="space-y-4">
           {(formData.processingPhases || []).length === 0 && (
             <EmptyState
-              message={
-                language === "el"
-                  ? "Δεν έχετε προσθέσει φάσεις επεξεργασίας"
-                  : "No processing phases added"
-              }
+              messageKey="processing.phases.empty"
               icon={<Settings className="w-8 h-8 mb-2 text-gray-400" />}
             />
           )}

--- a/src/components/WorkersList.tsx
+++ b/src/components/WorkersList.tsx
@@ -69,7 +69,7 @@ const WorkersList: React.FC<WorkersListProps> = ({
       <CardContent className="space-y-4 p-6">
         {workers.length === 0 && (
           <EmptyState
-            message="Ξεκινήστε προσθέτοντας εργαζόμενους"
+            messageKey="workers.empty"
             icon={<Users className="w-8 h-8 mb-2 text-gray-400" />}
           />
         )}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,19 +1,18 @@
 import React from "react";
 import { AlertCircle } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
 interface EmptyStateProps {
-  message?: string;
+  messageKey: string;
   icon?: React.ReactNode;
 }
 
-const EmptyState: React.FC<EmptyStateProps> = ({
-  message = "Δεν υπάρχουν δεδομένα",
-  icon,
-}) => {
+const EmptyState: React.FC<EmptyStateProps> = ({ messageKey, icon }) => {
+  const { t } = useLanguage();
   return (
     <div className="flex flex-col items-center justify-center p-6 text-center text-sm text-gray-600">
       {icon ? icon : <AlertCircle className="w-8 h-8 mb-2 text-gray-400" />}
-      <p>{message}</p>
+      <p>{t(messageKey)}</p>
     </div>
   );
 };

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -75,7 +75,14 @@ const translations = {
     'reset': 'Επαναφορά',
     'export.pdf': 'Εξαγωγή PDF',
     'add.worker': 'Προσθήκη Εργαζομένου',
-    'remove.worker': 'Αφαίρεση Εργαζομένου'
+    'remove.worker': 'Αφαίρεση Εργαζομένου',
+
+    // Empty states
+    'empty.no.data': 'Δεν υπάρχουν δεδομένα',
+    'workers.empty': 'Ξεκινήστε προσθέτοντας εργαζόμενους',
+    'processing.phases.empty': 'Δεν έχετε προσθέσει φάσεις επεξεργασίας',
+    'batches.empty': 'Δεν υπάρχουν παρτίδες',
+    'costs.empty': 'Δεν υπάρχουν δεδομένα κόστους'
   },
   en: {
     // Basic fields
@@ -129,7 +136,14 @@ const translations = {
     'reset': 'Reset',
     'export.pdf': 'Export PDF',
     'add.worker': 'Add Worker',
-    'remove.worker': 'Remove Worker'
+    'remove.worker': 'Remove Worker',
+
+    // Empty states
+    'empty.no.data': 'No data available',
+    'workers.empty': 'Start by adding workers',
+    'processing.phases.empty': 'No processing phases added',
+    'batches.empty': 'No batches available',
+    'costs.empty': 'No cost data available'
   }
 };
 


### PR DESCRIPTION
## Summary
- translate EmptyState messages with `useLanguage`
- pass translation keys in WorkersList, ProcessingPhases, BatchManagement, CostAnalysisPanel
- add translation strings for new keys

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eab7ab9d88328929bd75958c4dd7f