### PR TITLE
Add Jest tests and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@
    ```bash
    npm run lint
    ```
-3. Εκτέλεση σε περιβάλλον ανάπτυξης
+3. Εκτέλεση unit tests
+   ```bash
+   npm test
+   ```
+4. Εκτέλεση σε περιβάλλον ανάπτυξης
    ```bash
    npm run dev
    ```
-4. Δημιουργία παραγωγικού build
+5. Δημιουργία παραγωγικού build
    ```bash
    npm run build
    ```
-5. Deploy στο Vercel
+6. Deploy στο Vercel
    Κάντε push το repository στο GitHub και το Vercel θα αναλάβει αυτόματα το deployment.
 
 ## Μεταβλητές Περιβάλλοντος

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transform: {},
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: 'tsconfig.json'
+    }
+  }
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -86,6 +87,12 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Dashboard from '../Dashboard';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+
+describe('Dashboard', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <LanguageProvider>{children}</LanguageProvider>
+  );
+
+  test('renders without crashing', () => {
+    render(<Dashboard />, { wrapper });
+    expect(screen.getByText('Ταμπλό Αναλυτικών')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ResultsSection.test.tsx
+++ b/src/components/__tests__/ResultsSection.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import ResultsSection from '../ResultsSection';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+
+describe('ResultsSection', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <LanguageProvider>{children}</LanguageProvider>
+  );
+
+  const mockResults = {
+    totalCost: 1,
+    totalCostWithVat: 1.24,
+    sellingPrice: 2,
+    profitPerKg: 0.5,
+    profitMargin: 20,
+    netWeight: 1,
+    purchaseCost: 0.5,
+    laborCost: 0.1,
+    packagingCost: 0.05,
+    transportCost: 0.1,
+    additionalCosts: 0.05,
+    vatAmount: 0.24,
+    finalProcessedWeight: 1,
+    totalWastePercentage: 0,
+    costBreakdown: [],
+    recommendedSellingPrice: 2.2,
+    competitorAnalysis: {
+      ourPrice: 2,
+      competitor1Diff: 0,
+      competitor2Diff: 0,
+      marketPosition: 'competitive',
+    },
+    profitAnalysis: {
+      breakEvenPrice: 1,
+      marginAtCurrentPrice: 20,
+      recommendedMargin: 25,
+    },
+  };
+
+  const mockForm = { competitor1: 0, competitor2: 0 };
+
+  test('renders without crashing', () => {
+    render(
+      <ResultsSection
+        results={mockResults}
+        formData={mockForm}
+        isCalculating={false}
+        onCalculate={async () => {}}
+        onReset={() => {}}
+      />,
+      { wrapper }
+    );
+    expect(
+      screen.getByText('Κοστολόγηση Προϊόντος')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/exportUtils.test.ts
+++ b/src/utils/__tests__/exportUtils.test.ts
@@ -1,0 +1,47 @@
+import * as Utils from '../exportUtils';
+import * as XLSX from 'xlsx';
+import { saveAs } from 'file-saver';
+
+jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+
+jest.mock('xlsx', () => {
+  return {
+    utils: {
+      json_to_sheet: jest.fn(() => 'sheet'),
+      sheet_to_csv: jest.fn(() => 'csv'),
+      book_new: jest.fn(() => 'wb'),
+      book_append_sheet: jest.fn(),
+    },
+    writeFile: jest.fn(),
+  };
+});
+
+describe('exportUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('exportToCSV uses correct data', () => {
+    const data = { a: 1, b: 2 };
+    Utils.exportToCSV(data, 'file');
+    expect(XLSX.utils.json_to_sheet).toHaveBeenCalledWith([data]);
+    expect(XLSX.utils.sheet_to_csv).toHaveBeenCalledWith('sheet');
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'file.csv');
+  });
+
+  test('exportToXLSX uses correct data', () => {
+    const data = { a: 1 };
+    Utils.exportToXLSX(data, 'excel');
+    expect(XLSX.utils.json_to_sheet).toHaveBeenCalledWith([data]);
+    expect(XLSX.utils.book_new).toHaveBeenCalled();
+    expect(XLSX.utils.book_append_sheet).toHaveBeenCalledWith('wb', 'sheet', 'Sheet1');
+    expect(XLSX.writeFile).toHaveBeenCalledWith('wb', 'excel.xlsx');
+  });
+
+  test('exportToPDF calls generatePDFBlob and saveAs', async () => {
+    const spy = jest.spyOn(Utils, 'generatePDFBlob').mockResolvedValue(new Blob(['pdf']));
+    await Utils.exportToPDF('<div></div>', 'doc', { sections: {} });
+    expect(spy).toHaveBeenCalledWith('<div></div>', { sections: {} });
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'doc.pdf');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest, React Testing Library and config
- write unit tests for export utilities
- add render tests for Dashboard and ResultsSection
- document running `npm test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eab7c54648328b0cfba2ce214f07d