### PR TITLE
Use react-pdf-viewer for export preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,8 @@
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "qrcode": "^1.5.1",
+        "@react-pdf-viewer/core": "^3.12.0",
+        "@react-pdf-viewer/default-layout": "^3.12.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "xlsx": "^0.18.5",
     "zod": "^3.23.8",
     "jspdf": "^2.5.1",
-    "qrcode": "^1.5.1"
+    "qrcode": "^1.5.1",
+    "@react-pdf-viewer/core": "^3.12.0",
+    "@react-pdf-viewer/default-layout": "^3.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/ExportPreview.tsx
+++ b/src/components/ExportPreview.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import { Worker, Viewer } from '@react-pdf-viewer/core';
+import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
+import '@react-pdf-viewer/core/lib/styles/index.css';
+import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 
 interface ExportPreviewProps {
   preview: string;
@@ -9,6 +13,10 @@ interface ExportPreviewProps {
 }
 
 const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, pdfSrc, theme, onThemeChange, children }) => {
+  const defaultLayoutPluginInstance = React.useMemo(() => defaultLayoutPlugin(), []);
+
+  const canDisplayPdf = typeof navigator !== 'undefined' && !!navigator.mimeTypes?.['application/pdf'];
+
   return (
     <div className="flex flex-col lg:flex-row gap-4">
       <div className="lg:w-1/2 space-y-4">
@@ -18,7 +26,7 @@ const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, pdfSrc, theme, o
           <select
             id="template"
             value={theme}
-            onChange={e => onThemeChange(e.target.value as 'classic' | 'modern' | 'minimal')}
+            onChange={(e) => onThemeChange(e.target.value as 'classic' | 'modern' | 'minimal')}
             className="w-full border rounded p-2"
           >
             <option value="classic">Classic</option>
@@ -29,7 +37,13 @@ const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, pdfSrc, theme, o
       </div>
       <div className="lg:w-1/2 border rounded bg-white h-96 overflow-hidden">
         {pdfSrc ? (
-          <iframe title="preview" className="w-full h-full" src={pdfSrc} />
+          canDisplayPdf ? (
+            <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js">
+              <Viewer fileUrl={pdfSrc} plugins={[defaultLayoutPluginInstance]} />
+            </Worker>
+          ) : (
+            <iframe title="preview" className="w-full h-full" src={pdfSrc} />
+          )
         ) : (
           <iframe title="preview" className="w-full h-full" srcDoc={preview} />
         )}


### PR DESCRIPTION
## Summary
- add `@react-pdf-viewer` dependencies
- render generated PDF blob via `Viewer` component with page and zoom controls
- keep iframe fallback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eab7dff2c8328a5316de4e7d546a1