### PR TITLE
Add company settings and PDF export info

### DIFF
--- a/src/components/CompanySettings.tsx
+++ b/src/components/CompanySettings.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { FileImage, Building2, MapPin } from 'lucide-react';
+import { CompanyInfo } from '@/types/company';
+
+interface CompanySettingsProps {
+  onChange?: (info: CompanyInfo) => void;
+}
+
+const CompanySettings: React.FC<CompanySettingsProps> = ({ onChange }) => {
+  const [info, setInfo] = useState<CompanyInfo>({ logoUrl: '', name: '', address: '' });
+
+  useEffect(() => {
+    const stored = localStorage.getItem('companyInfo');
+    if (stored) {
+      const parsed: CompanyInfo = JSON.parse(stored);
+      setInfo(parsed);
+      onChange?.(parsed);
+    }
+  }, [onChange]);
+
+  const handleSave = () => {
+    localStorage.setItem('companyInfo', JSON.stringify(info));
+    onChange?.(info);
+  };
+
+  return (
+    <Card className="shadow-lg border-0">
+      <CardHeader className="bg-gradient-to-r from-emerald-600 to-teal-600 text-white">
+        <CardTitle className="text-white">Company Settings</CardTitle>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        <div>
+          <Label className="flex items-center space-x-2">
+            <FileImage className="w-4 h-4" />
+            <span>Logo URL</span>
+          </Label>
+          <Input
+            value={info.logoUrl || ''}
+            onChange={(e) => setInfo({ ...info, logoUrl: e.target.value })}
+            placeholder="https://example.com/logo.png"
+            className="mt-1"
+          />
+        </div>
+        <div>
+          <Label className="flex items-center space-x-2">
+            <Building2 className="w-4 h-4" />
+            <span>Company Name</span>
+          </Label>
+          <Input
+            value={info.name || ''}
+            onChange={(e) => setInfo({ ...info, name: e.target.value })}
+            placeholder="My Company"
+            className="mt-1"
+          />
+        </div>
+        <div>
+          <Label className="flex items-center space-x-2">
+            <MapPin className="w-4 h-4" />
+            <span>Address</span>
+          </Label>
+          <Input
+            value={info.address || ''}
+            onChange={(e) => setInfo({ ...info, address: e.target.value })}
+            placeholder="123 Street"
+            className="mt-1"
+          />
+        </div>
+        <div className="flex justify-end pt-2">
+          <Button onClick={handleSave}>Save</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CompanySettings;

--- a/src/components/PDFExport.tsx
+++ b/src/components/PDFExport.tsx
@@ -8,9 +8,12 @@ import { toast } from 'sonner';
 import ExportPreview from './ExportPreview';
 import { exportToPDF, generatePDFBlob } from '@/utils/exportUtils';
 
+import { CompanyInfo } from '@/types/company';
+
 interface PDFExportProps {
   results: any;
   formData: any;
+  companyInfo?: CompanyInfo;
 }
 
 type Template = 'classic' | 'modern' | 'minimal';
@@ -42,7 +45,7 @@ const templates = {
   }
 } as const;
 
-const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
+const PDFExport: React.FC<PDFExportProps> = ({ results, formData, companyInfo }) => {
   const { language } = useLanguage();
   const [selectedCharts, setSelectedCharts] = useState({
     costBreakdown: true,
@@ -92,11 +95,16 @@ const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
     const themeCSS = `
       body { font-family: ${t.font}; background: ${theme === 'dark' ? '#1f2937' : t.background}; color: ${theme === 'dark' ? '#fff' : t.text}; margin:20px; }
       .header { background: ${t.headerBg}; color:${t.headerColor}; text-align:center; padding:20px; }
+      .logo { max-height:60px; margin-bottom:10px; }
       .section{margin-bottom:20px}
     `;
 
+    const logo = companyInfo?.logoUrl ? `<img src="${companyInfo.logoUrl}" class="logo" />` : `<div>${t.logo}</div>`;
+    const name = companyInfo?.name ? `<h2>${companyInfo.name}</h2>` : '';
+    const address = companyInfo?.address ? `<p>${companyInfo.address}</p>` : '';
+
     return `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>${title}</title><style>${themeCSS}</style></head><body>
-      <div class="header"><div>${t.logo}</div><h1>${title}</h1>
+      <div class="header">${logo}${name}<h1>${title}</h1>${address}
         <p><strong>${productLabel}</strong> ${formData.productName || ''}</p>
         <p><strong>${dateLabel}</strong> ${new Date().toLocaleDateString()}</p>
       </div>
@@ -111,7 +119,7 @@ const PDFExport: React.FC<PDFExportProps> = ({ results, formData }) => {
     </body></html>`;
   };
 
-  const previewHtml = useMemo(buildHtmlContent, [results, formData, template, selectedCharts, language, includeTables, includeComments, includeQr, theme]);
+  const previewHtml = useMemo(buildHtmlContent, [results, formData, template, selectedCharts, language, includeTables, includeComments, includeQr, theme, companyInfo]);
 
   useEffect(() => {
     const generate = async () => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,12 +13,23 @@ import ResultsSection from '@/components/ResultsSection';
 import PDFExport from '@/components/PDFExport';
 import DataExport from '@/components/DataExport';
 import SmartInsightsPanel from '@/components/SmartInsightsPanel';
+import CompanySettings from '@/components/CompanySettings';
+import { CompanyInfo } from '@/types/company';
 
 const Index = () => {
   const { formData, updateFormData, calculate, resetForm, results, isCalculating } = useCalculation();
   const [activeTab, setActiveTab] = useState('basics');
   const [showFileUpload, setShowFileUpload] = useState(false);
   const [isPremium, setIsPremium] = useState(false);
+  const [companyInfo, setCompanyInfo] = useState<CompanyInfo>(() => {
+    const stored = localStorage.getItem('companyInfo');
+    return stored ? JSON.parse(stored) : { logoUrl: '', name: '', address: '' };
+  });
+
+  const handleCompanyChange = (info: CompanyInfo) => {
+    setCompanyInfo(info);
+    localStorage.setItem('companyInfo', JSON.stringify(info));
+  };
 
   const handleFileUpload = (data: any) => {
     updateFormData(data);
@@ -86,12 +97,15 @@ const Index = () => {
               <SmartInsightsPanel results={results} formData={formData} />
             )}
 
-            {results && (
-              <div data-tour="export" className="space-y-4">
-                <PDFExport formData={formData} results={results} />
-                <DataExport formData={formData} results={results} />
-              </div>
-            )}
+            <div data-tour="export" className="space-y-4">
+              <CompanySettings onChange={handleCompanyChange} />
+              {results && (
+                <>
+                  <PDFExport formData={formData} results={results} companyInfo={companyInfo} />
+                  <DataExport formData={formData} results={results} />
+                </>
+              )}
+            </div>
 
             {/* Premium Info Card */}
             {!isPremium && (

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,0 +1,5 @@
+export interface CompanyInfo {
+  logoUrl?: string;
+  name?: string;
+  address?: string;
+}


### PR DESCRIPTION
## Summary
- add `CompanySettings` panel for editing logo URL, company name and address
- include new company information in PDF export HTML
- store company details in local storage and pass them through the Index page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eab7fb68c83288151e9aa40d1c210