### PR TITLE
Clean README env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@
 5. Deploy στο Vercel
    Κάντε push το repository στο GitHub και το Vercel θα αναλάβει αυτόματα το deployment.
 
-## Μεταβλητές Περιβάλλοντος
-
-Χρησιμοποιήστε `.env` τοπικά και `.env.production` στο Vercel για να ορίσετε μεταβλητές όπως:
-
-```ini
-VITE_API_URL=https://api.example.com
-```
-
 ## Δομή Φακέλων
 
 ```


### PR DESCRIPTION
## Summary
- remove unused `VITE_API_URL` example

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eab814860832888402eb611b3ee76