### PR TITLE
Fix web worker initialization in calculation hook

### DIFF
--- a/src/hooks/useCalculation.ts
+++ b/src/hooks/useCalculation.ts
@@ -60,7 +60,7 @@ export const useCalculation = () => {
   const workerRef = useRef<Worker>();
 
   useEffect(() => {
-    if (typeof Worker !== 'undefined') {
+    if (typeof window !== 'undefined' && typeof Worker !== 'undefined') {
       workerRef.current = new Worker(new URL('../workers/calculateWorker.ts', import.meta.url), { type: 'module' });
     }
     return () => {


### PR DESCRIPTION
## Summary
- avoid creating a worker when window isn't defined

## Testing
- `bun test` *(fails: Cannot find package 'xlsx' and module 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_685eb889cba883289d8053f1ef96637c