### PR TITLE
Fix React child validation

### DIFF
--- a/src/components/ExportPreview.tsx
+++ b/src/components/ExportPreview.tsx
@@ -5,28 +5,45 @@ import '@react-pdf-viewer/core/lib/styles/index.css';
 import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 
 interface ExportPreviewProps {
-  preview: string;
-  theme: 'classic' | 'modern' | 'minimal';
-  onThemeChange: (theme: 'classic' | 'modern' | 'minimal') => void;
-  children: React.ReactNode;
-  pdfSrc?: string;
+  /** HTML preview to render inside the iframe */
+  preview?: string
+  /** Currently selected theme */
+  theme?: 'classic' | 'modern' | 'minimal'
+  /** Callback when a new theme is picked */
+  onThemeChange?: (theme: 'classic' | 'modern' | 'minimal') => void
+  /** Children to display above the preview */
+  children?: React.ReactNode
+  /** Source of a previously generated PDF */
+  pdfSrc?: string
 }
 
-const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, pdfSrc, theme, onThemeChange, children }) => {
-  const defaultLayoutPluginInstance = React.useMemo(() => defaultLayoutPlugin(), []);
+const ExportPreview: React.FC<ExportPreviewProps> = ({
+  preview,
+  pdfSrc,
+  theme = 'classic',
+  onThemeChange,
+  children,
+}) => {
+  const defaultLayoutPluginInstance = React.useMemo(() => defaultLayoutPlugin(), [])
+
+  const safePreview = typeof preview === 'string' ? preview : ''
+  const safeChildren =
+    React.isValidElement(children) || Array.isArray(children) || typeof children === 'string'
+      ? children
+      : null
 
   const canDisplayPdf = typeof navigator !== 'undefined' && !!navigator.mimeTypes?.['application/pdf'];
 
   return (
     <div className="flex flex-col lg:flex-row gap-4">
       <div className="lg:w-1/2 space-y-4">
-        {children}
+        {safeChildren}
         <div>
           <label htmlFor="template" className="block text-sm font-medium mb-1">Template</label>
           <select
             id="template"
             value={theme}
-            onChange={(e) => onThemeChange(e.target.value as 'classic' | 'modern' | 'minimal')}
+            onChange={(e) => onThemeChange?.(e.target.value as 'classic' | 'modern' | 'minimal')}
             className="w-full border rounded p-2"
           >
             <option value="classic">Classic</option>
@@ -45,7 +62,7 @@ const ExportPreview: React.FC<ExportPreviewProps> = ({ preview, pdfSrc, theme, o
             <iframe title="preview" className="w-full h-full" src={pdfSrc} />
           )
         ) : (
-          <iframe title="preview" className="w-full h-full" srcDoc={preview} />
+          <iframe title="preview" className="w-full h-full" srcDoc={safePreview} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add validation and default props for `ExportPreview`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec25b24748328939b628e7345804f