### PR TITLE
Fix static path to built client

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,7 +68,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname, "../client/dist");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- update server's static asset path to the new client `dist` directory

## Testing
- `npm run check` *(fails: TypeScript errors)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff24ed8d8832891bf61e60d566a8d