### PR TITLE
Load dev banner only in dev

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,14 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
+    <!-- Load Replit's dev banner only in development -->
+    <script type="module">
+      if (import.meta.env.MODE === 'development') {
+        const s = document.createElement('script');
+        s.src = 'https://replit.com/public/js/replit-dev-banner.js';
+        s.async = true;
+        document.body.appendChild(s);
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add conditional logic in `index.html` so `replit-dev-banner.js` only loads in development

## Testing
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3b0ab04832889563d04060d88fa