### PR TITLE
Add end-of-string anchor to static asset regex

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|webp|mp4|webm|ogg|mp3|wav|flac|aac|pdf))",
+      "source": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|webp|mp4|webm|ogg|mp3|wav|flac|aac|pdf))$",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Add `$` anchor to the end of the static asset file extension regex pattern in vercel.json.

This change ensures the regex pattern matches only when the file extension is at the end of the URL path, preventing partial matches within the URL.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 69`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef75725b4ca54bc48497f7217de1a285/mystic-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef75725b4ca54bc48497f7217de1a285</projectId>-->
<!--<branchName>mystic-hub</branchName>-->