### PR TITLE
Update Vercel caching rule

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|webp|mp4|webm|ogg|mp3|wav|flac|aac|pdf))",
+      "source": "/:path*.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|webp|mp4|webm|ogg|mp3|wav|flac|aac|pdf)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- replace regex header rule with Vercel wildcard syntax

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686315ce67388328b8f4a25b7ce961a4