### PR TITLE
Remove obsolete Vercel build config

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,20 +45,21 @@ Ensure your repository has these essential files:
 ```json
 {
   "version": 2,
-  "name": "kostopro-enhanced",
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
-  "routes": [
+  "headers": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "max-age=31536000, immutable" }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    }
-  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove the unused `builds` block from `vercel.json`
- update `DEPLOYMENT.md` to document the new Vercel configuration

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686850e62b2083289bcd2cf46578ed6c